### PR TITLE
Add deploy buttons to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,15 @@ A minimal static project containing a styled landing page and small script that 
 
 ## Deployment
 
-Deploy this project to any static host such as Vercel, Netlify, or TinyHost.
+Deploy this project to any static host such as Vercel, Netlify, or TinyHost.  
+You can also quickly spin up a Replit workspace or Hugging Face Space.
+
+### One-click Deploy
+
+[![Deploy to Vercel](https://vercel.com/button)](https://vercel.com/new/git/external?repository-url=https://github.com/your-username/Nothin1)
+[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/your-username/Nothin1)
+[![Run on Replit](https://repl.it/badge/github/your-username/Nothin1)](https://repl.it/github/your-username/Nothin1)
+[![Deploy on Hugging Face](https://img.shields.io/badge/Deploy%20to-Hugging%20Face-blue)](https://huggingface.co/spaces/your-username/Nothin1)
 
 ### Vercel
 1. Install the [Vercel CLI](https://vercel.com/docs/cli).
@@ -13,6 +21,12 @@ Deploy this project to any static host such as Vercel, Netlify, or TinyHost.
 
 ### Netlify / TinyHost
 For Netlify or TinyHost, simply drop the repository contents into their web interface or use their CLI tools.
+
+### Replit
+Click the "Run on Replit" button above or go to [Replit](https://replit.com/) and import the repository. Replit will install dependencies automatically and serve the site.
+
+### Hugging Face
+You can also deploy this static site as a [Hugging Face Space](https://huggingface.co/spaces). Use the "Deploy on Hugging Face" button to create a new Space backed by this repository.
 
 The `vercel.json` file rewrites the root path to `index.html` so the landing page serves correctly.
 


### PR DESCRIPTION
## Summary
- add one-click deploy buttons for Vercel, Netlify, Replit and Hugging Face
- document deploy instructions for Replit and Hugging Face

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687934d49a78832d84048fd86558c3b1